### PR TITLE
#10 - removing ambiguous matches for Eloquent actions

### DIFF
--- a/src/Features/Traits/Eloquent.php
+++ b/src/Features/Traits/Eloquent.php
@@ -10,14 +10,12 @@ use PHPUnit\Framework\Assert;
 trait Eloquent
 {
     /**
-     * @Given there are no :model objects in database
-     * @Given there should be no :model objects in database
      * @Given there is :count :model object in database
      * @Given there should be :count :model object in database
      * @Given there are :count :model objects in database
      * @Given there should be :count :model objects in database
      */
-    public function thereAreModelsInDatabase(string $model, int $count = 0): void
+    public function thereAreModelsInDatabase(string $model, int $count): void
     {
         $modelClass = $this->recognizeModelClass($model);
         Assert::assertEquals($count, $modelClass::query()->count());


### PR DESCRIPTION
Use of
```
there should be no "Submission" objects in database
```
resulted with:
```
    And there should be no "Submission" objects in database
      Ambiguous match of "there should be no "Submission" objects in database":
      to `there should be :count :model objects in database` from App\Conference\Testing\Context::thereAreModelsInDatabase()
      to `there should be no :model objects in database` from App\Conference\Testing\Context::thereAreModelsInDatabase()

--- Failed scenarios:

    features/public/submissions.feature:10
```

I am dropping support for semantic `no`. Users will need to use `0` integer instead until I figure out how to distinct them in proper way.

This closes #10.