### PR TITLE
#19 - CSRF protection ready to be disabled

### DIFF
--- a/src/Features/Traits/Middleware.php
+++ b/src/Features/Traits/Middleware.php
@@ -47,4 +47,12 @@ trait Middleware
     {
         $this->disableMiddleware(LaravelContracts::THROTTLING_MIDDLEWARE_CLASS);
     }
+
+    /**
+     * @Given there's throttling middleware disabled
+     */
+    public function disableCsrfProtection(): void
+    {
+        $this->disableMiddleware(LaravelContracts::CSRF_PROTECTION_MIDDLEWARE_CLASS);
+    }
 }

--- a/src/Features/Traits/Middleware.php
+++ b/src/Features/Traits/Middleware.php
@@ -49,7 +49,7 @@ trait Middleware
     }
 
     /**
-     * @Given there's throttling middleware disabled
+     * @Given there's CSRF protection middleware disabled
      */
     public function disableCsrfProtection(): void
     {

--- a/src/LaravelContracts.php
+++ b/src/LaravelContracts.php
@@ -7,5 +7,6 @@ namespace Blumilk\BLT;
 class LaravelContracts
 {
     public const THROTTLING_MIDDLEWARE_CLASS = "Illuminate\Routing\Middleware\ThrottleRequests";
+    public const CSRF_PROTECTION_MIDDLEWARE_CLASS = "Illuminate\Foundation\Http\Middleware\VerifyCsrfToken";
     public const LOAD_CONFIGURATION_CLASS = "Illuminate\Foundation\Bootstrap\LoadConfiguration";
 }


### PR DESCRIPTION
```gherkin
Given there's CSRF protection middleware disabled
```
Above should turn off CSRF protection for requests during testing.

This is part of #19 issue.