### PR TITLE
#18 - handling sessions errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,10 @@
   ],
   "require": {
     "php": "^8.1",
-    "behat/behat": "^3.10.0",
-    "phpunit/phpunit": "^9.5|^10.0"
+    "behat/behat": "^3.12",
+    "phpunit/phpunit": "^9.5",
+    "symfony/css-selector": "^6.2",
+    "symfony/dom-crawler": "^6.2"
   },
   "require-dev": {
     "blumilksoftware/codestyle": "^1.10",

--- a/src/Features/Hooks/RebootAfterFeature.php
+++ b/src/Features/Hooks/RebootAfterFeature.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\BLT\Features\Hooks;
+
+use Blumilk\BLT\Bootstrapping\BootstrapperContract;
+use Blumilk\BLT\Bootstrapping\LaravelBootstrapper;
+
+trait RebootAfterFeature
+{
+    /**
+     * @afterFeature
+     */
+    public static function rebootAfterFeature(): void
+    {
+        $bootstrapper = static::getRebootAfterFeatureBootstrapper();
+        $bootstrapper->boot();
+    }
+
+    protected static function getRebootAfterFeatureBootstrapper(): BootstrapperContract
+    {
+        return new LaravelBootstrapper();
+    }
+}

--- a/src/Features/Traits/Application.php
+++ b/src/Features/Traits/Application.php
@@ -4,10 +4,35 @@ declare(strict_types=1);
 
 namespace Blumilk\BLT\Features\Traits;
 
+use Behat\Gherkin\Node\TableNode;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container;
 
 trait Application
 {
+    /**
+     * @Given there is :service service mocked with :mock
+     * @throws BindingResolutionException
+     */
+    public function thereIsServiceMocked(string $service, string $mock): void
+    {
+        $this->getContainer()->instance(
+            abstract: $service,
+            instance: $this->getContainer()->make($mock),
+        );
+    }
+
+    /**
+     * @Given there are services mocked:
+     * @throws BindingResolutionException
+     */
+    public function thereAreServicesMocked(TableNode $table): void
+    {
+        foreach ($table as $row) {
+            $this->thereIsServiceMocked($row["service"], $row["mock"]);
+        }
+    }
+
     protected function getContainer(): Container
     {
         return app();

--- a/src/Features/Traits/Session.php
+++ b/src/Features/Traits/Session.php
@@ -4,6 +4,33 @@ declare(strict_types=1);
 
 namespace Blumilk\BLT\Features\Traits;
 
+use Behat\Gherkin\Node\TableNode;
+use Illuminate\Support\ViewErrorBag;
+use PHPUnit\Framework\Assert;
+
 trait Session
 {
+    /**
+     * @Then a session flashes errors:
+     */
+    public function sessionFlashesErrors(TableNode $table): void
+    {
+        /** @var ViewErrorBag $errors */
+        $errors = $this->getContainer()->get("session")->all()["errors"];
+        Assert::assertSameSize($table->getHash(), $errors);
+
+        foreach ($table as $row) {
+            Assert::assertEquals($row["message"], $errors->get($row["key"])[$row["index"]]);
+        }
+    }
+
+    /**
+     * @Given a session flashes no errors
+     */
+    public function aSessionFlashesNoErrors(): void
+    {
+        /** @var ViewErrorBag $errors */
+        $errors = $this->getContainer()->get("session")->all()["errors"] ?? [];
+        Assert::assertSameSize([], $errors);
+    }
 }


### PR DESCRIPTION
This PR should be a nice beginning for session features like:
```gherkin
    Then a session flashes errors:
      | key         | index | message                                                |
      | credentials | 0     | Provided data cannot be used to authenticate any user. |
```