### PR TITLE
#18 - add session tools

### DIFF
--- a/src/Features/Traits/Session.php
+++ b/src/Features/Traits/Session.php
@@ -33,4 +33,96 @@ trait Session
         $errors = $this->getContainer()->get("session")->all()["errors"] ?? [];
         Assert::assertSameSize([], $errors);
     }
+
+    /**
+     * @Given the session has the following data:
+     */
+    public function theSessionHasTheFollowingData(TableNode $table): void
+    {
+        $session = $this->getContainer()->get("session");
+
+        foreach ($table->getHash() as $row) {
+            $session->put($row["key"], $row["value"]);
+        }
+    }
+
+    /**
+     * @Then the session should have the following data:
+     */
+    public function theSessionShouldHaveTheFollowingData(TableNode $table): void
+    {
+        $session = $this->getContainer()->get("session");
+
+        foreach ($table->getHash() as $row) {
+            Assert::assertEquals($row["value"], $session->get($row["key"]));
+        }
+    }
+
+    /**
+     * @Given the session is revoked
+     */
+    public function theSessionIsRevoked(): void
+    {
+        $this->getContainer()->get("session")->invalidate();
+    }
+
+    /**
+     * @Given the session has no data
+     */
+    public function theSessionHasNoData(): void
+    {
+        $session = $this->getContainer()->get("session");
+        $session->flush();
+    }
+
+    /**
+     * @Given the session flashes the following data:
+     */
+    public function theSessionFlashesTheFollowingData(TableNode $table): void
+    {
+        $session = $this->getContainer()->get("session");
+
+        foreach ($table->getHash() as $row) {
+            $session->flash($row["key"], $row["value"]);
+        }
+    }
+
+    /**
+     * @Then the session should flash the following data:
+     */
+    public function theSessionShouldFlashTheFollowingData(TableNode $table): void
+    {
+        $session = $this->getContainer()->get("session");
+
+        foreach ($table->getHash() as $row) {
+            Assert::assertEquals($row["value"], $session->get($row["key"]));
+        }
+    }
+
+    /**
+     * @Then the session should have key :key
+     */
+    public function theSessionShouldHaveKey(string $key): void
+    {
+        $session = $this->getContainer()->get("session");
+        Assert::assertTrue($session->has($key));
+    }
+
+    /**
+     * @Then the session should not have key :key
+     */
+    public function theSessionShouldNotHaveKey(string $key): void
+    {
+        $session = $this->getContainer()->get("session");
+        Assert::assertFalse($session->has($key));
+    }
+
+    /**
+     * @Given the session forgets key :key
+     */
+    public function theSessionForgetsKey(string $key): void
+    {
+        $session = $this->getContainer()->get("session");
+        $session->forget($key);
+    }
 }

--- a/src/Features/Traits/Session.php
+++ b/src/Features/Traits/Session.php
@@ -118,7 +118,16 @@ trait Session
     }
 
     /**
-     * @Given the session forgets key :key
+     * @Then the session should have key :key with value :value
+     */
+    public function theSessionShouldHaveKeyWithValue(string $key, string $value): void
+    {
+        $session = $this->getContainer()->get("session");
+        Assert::assertEquals($value, $session->get($key));
+    }
+
+    /**
+     * @Given the session forgets the key :key
      */
     public function theSessionForgetsKey(string $key): void
     {


### PR DESCRIPTION
This should close #18 

Added session management methods for testing with behat. 

- Adding data to a session
- the session should contain the following data
- Clearing sessions and removing specific keys
- Manage data flashing in a session
